### PR TITLE
Replace staticfiles storage url with the static templatetag

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ exists:
     ```
 1. To include a static file url:
     ```mako
-    ${ static }/home.png
+    ${ static('image.png') }
     ```
 1. To reverse a url in the template:
     - Mako Template

--- a/djangomako/backends.py
+++ b/djangomako/backends.py
@@ -11,7 +11,7 @@ get_template() and optionally from_string().
 import tempfile
 
 from django.core.urlresolvers import reverse
-from django.contrib.staticfiles.storage import staticfiles_storage
+from django.contrib.staticfiles.templatetags.staticfiles import static
 from django.template import TemplateDoesNotExist, TemplateSyntaxError
 from django.template.backends.base import BaseEngine
 from django.template.backends.utils import csrf_input_lazy, \
@@ -156,7 +156,7 @@ class Template(object):
             context['csrf_input'] = csrf_input_lazy(request)
             context['csrf_token'] = csrf_token_lazy(request)
 
-            context['static'] = staticfiles_storage.url
+            context['static'] = static
             context['url'] = reverse
 
         return self.template.render(**context)


### PR DESCRIPTION
This is addressing #1 suggestion of using 
```PYTHON
django.contrib.staticfiles.templatetags.staticfiles.static
``` 
instead of 
```PYTHON
django.contrib.staticfiles.storage.staticfiles_storage.url
```

Using template tag to build the URL for the given relative path makes it much easier when you I to switch to a content delivery network (CDN) for serving static files.