### PR TITLE
prevent 'self' kwargs to be passed to Template.render

### DIFF
--- a/djangomako/backends.py
+++ b/djangomako/backends.py
@@ -159,4 +159,7 @@ class Template(object):
             context['static'] = static
             context['url'] = reverse
 
+        # prevent 'self' to be passed as kwargs
+        # but keep a fallback to 'this'
+        context['this'] = context.pop('self', None)
         return self.template.render(**context)


### PR DESCRIPTION
`self` can be passed to `Template.render` method which result to a `TypeError`:

```
render() got multiple values for argument 'self'
```

For example framework like [wagtail](https://wagtail.io/) use `self` in their context.

By the way this PR offer a fallback to `this` in place of `self`.

Another alternative could be an optional settings to defined a custom `Template` class from django's settings.

Let me know you through