### PR TITLE
Django 3 Import error Fixed

### DIFF
--- a/djangomako/backends.py
+++ b/djangomako/backends.py
@@ -11,7 +11,7 @@ get_template() and optionally from_string().
 import tempfile
 
 from django import get_version
-from django.contrib.staticfiles.templatetags.staticfiles import static
+from django.templatetags.static import static
 from django.template import TemplateDoesNotExist, TemplateSyntaxError
 from django.template.backends.base import BaseEngine
 from django.template.backends.utils import (


### PR DESCRIPTION
### Django 3 Import error Fixed

`from django.contrib.staticfiles.templatetags.staticfiles import static` is not supported for Django > 3, fixed the import error.